### PR TITLE
Update Kubernetes docs to use the Helm Repo in Commands

### DIFF
--- a/docs/installation/kubernetes/helm_chart.md
+++ b/docs/installation/kubernetes/helm_chart.md
@@ -16,7 +16,7 @@ helm search repo planka
 **Generate *SECRETKEY* and install Planka**
 ```bash
 export SECRETKEY=$(openssl rand -hex 64)
-helm install planka . --set secretkey=$SECRETKEY  \
+helm install planka planka/planka --set secretkey=$SECRETKEY  \
 --set admin_email="demo@demo.demo"  \
 --set admin_password="demo"  \
 --set admin_name="Demo Demo" \
@@ -36,7 +36,7 @@ kubectl port-forward $POD_NAME 3000:1337
 **To access Planka externally you can use the following configuration**
 ```bash
 # HTTP only
-helm install planka . --set secretkey=$SECRETKEY \
+helm install planka planka/planka --set secretkey=$SECRETKEY \
 --set admin_email="demo@demo.demo"  \
 --set admin_password="demo"  \
 --set admin_name="Demo Demo" \
@@ -45,7 +45,7 @@ helm install planka . --set secretkey=$SECRETKEY \
 --set ingress.hosts[0].host=planka.example.dev \
 
 # HTTPS
-helm install planka . --set secretkey=$SECRETKEY \
+helm install planka planka/planka --set secretkey=$SECRETKEY \
 --set admin_email="demo@demo.demo"  \
 --set admin_password="demo"  \
 --set admin_name="Demo Demo" \


### PR DESCRIPTION
Fixed a copy and paste error when creating the docs for Kubernetes.

The commands were referring to running the chart locally, but the start of the page shows how to use the Helm Repo.

By updating the `helm install planka . --set ...` to `helm install planka planka/planka --set ...` these instructions now make sense and will work.

For instructions on running locally can be found in the [Planka](https://github.com/plankanban/planka) repo.

https://github.com/plankanban/planka/issues/739