### PR TITLE
docs: Adding one-click deploy link to intro.md

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -11,6 +11,7 @@ We have a few installation options you can choose from
 * [Docker Compose](/docs/installation/docker/production_version.md)
 * [Kubernetes (Helm)](/docs/installation/kubernetes/helm_chart.md)
 * [Manual Installation](/docs/category/manual-installation)
+* [One-Click Deploy on RepoCloud](https://repocloud.io/details/?app_id=135)
 
 
 ### Configuration


### PR DESCRIPTION
Adding link enabling community access to one-click deploy template for self-hosting on RepoCloud.io