### PR TITLE
feat: update docs

### DIFF
--- a/docs/Configuration/Logging.md
+++ b/docs/Configuration/Logging.md
@@ -1,12 +1,17 @@
+---
+sidebar_position: 2
+---
 # Logging
 
-Planka currently allows you to expose the application's logfile directory to the host machine via a shared volume. This feature is not enabled by default.
+Planka currently allows you to expose the application's logfile directory to the host machine via a shared volume. This feature is **NOT** enabled by default.
 
 To expose the logfile director to the host machine, add the item `./logs/:/app/logs/` under `services.planka.volumes`.
 
 Note that the directory to the left of the semicolon is regarding the host machine while the directory to the right of the semicolon is regarding the Docker container.
 
 For example, in the above step, `./logs/:/app/logs/` will create the folder `logs` in the same directory where the `docker-compose.yml` file lives.
+
+If your logs are not being written to the logfile directory, you may need to adjust the permissions. See the information at the end of the [Docker Compose](/docs/installation/docker/production_version) guide for more information.
 
 ### Rotating Logs
 

--- a/docs/Configuration/security/Fail2Ban.md
+++ b/docs/Configuration/security/Fail2Ban.md
@@ -1,3 +1,6 @@
+---
+sidebar_position: 0
+---
 # Fail2ban
 
 Fail2ban is a service that uses iptables to automatically drop connections for a pre-defined amount of time from IPs that continuously failed to authenticate to the configured services.
@@ -28,7 +31,7 @@ maxretry = 5
 bantime = 900
 ```
 
-Ensure to replace `logpath`'s value with your installation’s `/logs/planka.log` location. If you are using ports other than 80 and 443 for your Web server you should replace those too. The bantime and findtime are defined in seconds.
+Ensure to replace `logpath`'s value with your installation’s `/logs/planka.log` location (Do not forget to enable [logs](/docs/Configuration/Logging)). If you are using ports other than 80 and 443 for your Web server you should replace those too. The bantime and findtime are defined in seconds.
 
 Restart the fail2ban service. You can check the status of your Planka jail by running:
 

--- a/docs/Configuration/security/_category_.json
+++ b/docs/Configuration/security/_category_.json
@@ -1,0 +1,9 @@
+{
+    "label": "Security",
+    "position": 3,
+    "link": {
+      "type": "generated-index",
+      "description": " All the configuration related to security."
+    }
+  }
+  

--- a/docs/Configuration/security/detailed_authentication_errors.md
+++ b/docs/Configuration/security/detailed_authentication_errors.md
@@ -1,4 +1,4 @@
-# Detail Authentication Errors
+# Detailed Authentication Errors
 
 By default, the authentication error messages are kept simple to avoid leaking sensitive information.
 

--- a/docs/Configuration/security/detailed_authentication_errors.md
+++ b/docs/Configuration/security/detailed_authentication_errors.md
@@ -1,0 +1,20 @@
+# Detail Authentication Errors
+
+By default, the authentication error messages are kept simple to avoid leaking sensitive information.
+
+However, in some cases, you may want to provide more detailed error messages to help users. In this case, you can enable detailed authentication errors.
+
+:::danger
+Enabling detailed authentication errors without a rate limiter or a similar mechanism may expose your application to security risks. (e.g. brute force attacks)
+Use [fail2ban](/docs/Configuration/security/Fail2Ban) or similar tools to protect your application.
+
+Good source for more information about this topic: [OWASP - Cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#authentication-and-error-messages)
+:::
+
+To enable detailed authentication errors, set the `SHOW_DETAILED_AUTH_ERRORS` environment variable to `true`.
+
+```bash
+SHOW_DETAILED_AUTH_ERRORS=true
+```
+
+After setting this environment variable, the authentication error messages will include more detailed information about the error : "Invalid email or username" and "Invalid password".

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -20,6 +20,10 @@ We have a few installation options you can choose from
 * [Traefik](/docs/Configuration/proxy/traefik)
 * [Caddy](/docs/Configuration/proxy/caddy)
 
+#### Security
+* [Fail2Ban](/docs/Configuration/security/fail2ban)
+* [Detailed authentication errors](/docs/Configuration/security/detailed_authentication_errors)
+
 
 ### Development version
 Based on latest commit


### PR DESCRIPTION
In this PR :
- Adding a point on the common issue about logs folder permissions
- Adding a security section in configuration
- Migrate Fail2ban conf in the security section
- Adding Detailed Auth Errors page on the security section
- Reorganize some page order (example: logging before security to have logging before fail2ban)