### PR TITLE
Update debian-and-ubuntu.md

### DIFF
--- a/docs/installation/manual/debian-and-ubuntu.md
+++ b/docs/installation/manual/debian-and-ubuntu.md
@@ -117,7 +117,7 @@ node -v
 Install required packages:
 
 ```bash
-sudo apt install unzip build-essential -y
+sudo apt install unzip build-essential python3-venv -y
 ```
 
 Create the installation directory and set ownership:
@@ -219,3 +219,4 @@ npm start --prod
 ## Access PLANKA
 
 Once the services are running, browse to **http://YOUR_DOMAIN_NAME:YOUR_PORT** and log in as **YOUR_ADMIN_EMAIL** with the password **YOUR_ADMIN_PASSWORD**.
+


### PR DESCRIPTION
Add python3-venv as dependency to install.

I tried to install planka nightly on a freshly installed Ubuntu 24.04.3.

The npm install failed with:

```
planka@planka-Latitude-D830:/var/www/planka$ npm install

> planka@2.0.0-rc.3 postinstall
> npm i --prefix server && npm i --prefix client


> postinstall
> patch-package && npm run setup-python

patch-package 8.0.0
Applying patches...
sails@1.5.15 ✔
skipper-disk@0.5.12 ✔
waterline@0.15.2 ✔

> setup-python
> python3 -m venv .venv && .venv/bin/pip3 install -r requirements.txt

The virtual environment was not created successfully because ensurepip is not
available.  On Debian/Ubuntu systems, you need to install the python3-venv
package using the following command.

    apt install python3.12-venv

You may need to use sudo with that command.  After installing the python3-venv
package, recreate your virtual environment.

Failing command: /var/www/planka/server/.venv/bin/python3

npm error code 1
npm error path /var/www/planka/server
npm error command failed
npm error command sh -c patch-package && npm run setup-python
npm error A complete log of this run can be found in: /home/planka/.npm/_logs/2025-08-30T19_45_15_535Z-debug-0.log
npm error code 1
npm error path /var/www/planka
npm error command failed
npm error command sh -c npm i --prefix server && npm i --prefix client
npm notice
npm notice New major version of npm available! 10.9.3 -> 11.5.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.5.2
npm notice To update run: npm install -g npm@11.5.2
npm notice
npm error A complete log of this run can be found in: /home/planka/.npm/_logs/2025-08-30T19_44_57_491Z-debug-0.log
```

So I added the python3-venv to the install docs.