### PR TITLE
add X-Forwarded-Proto header to Caddy config for OIDC/SSO

### DIFF
--- a/docs/configuration/reverse-proxy/caddy.md
+++ b/docs/configuration/reverse-proxy/caddy.md
@@ -24,9 +24,14 @@ Replace placeholders with your actual email and domain:
 }
 
 your.domain.tld {
-    reverse_proxy http://localhost:3000
+    reverse_proxy http://localhost:3000 {
+        header_up X-Forwarded-Proto {scheme}
+    }
 }
+
 ```
+
+Note: The header_up X-Forwarded-Proto {scheme} directive is strictly required if you plan to use OIDC (SSO) or other secure session features. It ensures the backend Node.js server correctly identifies the original request as HTTPS.
 
 This config enables automatic HTTPS via Let's Encrypt.
 


### PR DESCRIPTION
This PR updates the Caddy reverse proxy documentation to explicitly include the `header_up X-Forwarded-Proto {scheme}` directive.

**Why is this needed?**
When using OIDC (SSO) or other secure session features behind Caddy, the backend Node.js server requires confirmation that the original request was made over HTTPS. 

Without this header explicitly passed, SSO login attempts fail with a `502 Bad Gateway` error. The backend abruptly closes the connection (resulting in a `ContentLength=2 with Body length 0` TCP disconnect error in Caddy) because it rejects the secure payload over what it perceives as an insecure HTTP connection. 

Adding this note will help future Caddy users avoid this frustrating debugging process!