### PR TITLE
docs: document helm configuration for custom terms of service

### DIFF
--- a/docs/configuration/customizing-end-user-terms.md
+++ b/docs/configuration/customizing-end-user-terms.md
@@ -115,6 +115,30 @@ docker compose down
 docker compose up -d
 ```
 
+### Kubernetes / Helm Installation
+
+When deploying PLANKA using the official Helm chart, you can configure your custom terms directly inside your `values.yaml` using the `terms` definition block.
+
+```yaml
+terms:
+  enabled: true
+  customFiles:
+    en-US.md: |
+      # End User Terms of Service
+      ...
+      [confirmations]::
+      ---
+      ✔️ **I have read and accept these End User Terms of Service**
+    de-DE.md: |
+      # Nutzungsbedingungen
+      ...
+      [confirmations]::
+      ---
+      ✔️ **Ich habe diese Nutzungsbedingungen gelesen und akzeptiere sie**
+```
+
+The Helm chart will automatically create a configuration map with your provided Markdown files and mount it to `/app/terms/custom`.
+
 ## Important Notes
 
 - If no custom Terms are found, PLANKA will fall back to the built-in template.


### PR DESCRIPTION
This PR updates the "Customizing End User Terms" configuration guide to include native instructions for Kubernetes deployments using the official Planka Helm chart.

It accompanies a new feature in the main `planka` repository that introduces first-class support for `terms` natively inside `values.yaml` without requiring users to manually manage separate ConfigMaps or complex extra volume mounts.

### Key Changes
- Added a `### Kubernetes / Helm Installation` section to `docs/configuration/customizing-end-user-terms.md`.
- Provided a clear YAML example of injecting custom Terms (e.g., `en-US.md` and `de-DE.md`) directly into the Helm `values.yaml` file natively using the new `terms.customFiles` mapping syntax.

## Related PRs
- Planka Backend/Helm Updates: https://github.com/plankanban/planka/pull/1585