### PR TITLE
Add plnk to community projects

### DIFF
--- a/docs/community/projects.md
+++ b/docs/community/projects.md
@@ -22,6 +22,10 @@ An API wrapper for PHP.
 
 An API wrapper for Python.
 
+### [plnk](https://github.com/plattnum/planka-cli)
+
+A scriptable Rust CLI and SDK for PLANKA, plus a live terminal TUI explorer. Built for shell scripts, CI/CD pipelines, and AI agents.
+
 ### [kanban-mcp](https://github.com/bradrisse/kanban-mcp)
 
 A middleware that lets Large Language Models (LLMs) interact seamlessly with PLANKA boards via a simplified API.


### PR DESCRIPTION
I've been using PLANKA for a while, self-hosted at home, for my indie and life projects. After trying all sorts of "vibe" kanban boards and agent-driving kanban boards, I came back to familiar ground with PLANKA for collaboration between myself and my agents — building on the already incredible work here rather than reinventing it.

My goal was to expose PLANKA to my terminal and let agents work with it quickly and efficiently.

It's still a work in progress, but I wanted to share it back with the community.

- Repo: https://github.com/plattnum/planka-cli
- Landing: https://plattnum.github.io/planka-cli

Thanks for building PLANKA and maintaining these docs — happy to adjust the entry if you'd prefer different wording or placement.